### PR TITLE
Increment version to 4.0

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>jakarta.servlet.jsp</groupId>
     <artifactId>jakarta.servlet.jsp-api</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Jakarta Server Pages API</name>
@@ -76,7 +76,7 @@
 
     <properties>
         <!-- Make sure the two versions are in sync with the maven version -->
-        <spec.version>3.1</spec.version>
+        <spec.version>4.0</spec.version>
         <bundle.version>${project.version}</bundle.version>
         <extensionName>jakarta.servlet.jsp</extensionName>
         <bundle.symbolicName>jakarta.servlet.jsp-api</bundle.symbolicName>

--- a/api/src/main/javadoc/doc-files/EFSL.html
+++ b/api/src/main/javadoc/doc-files/EFSL.html
@@ -41,10 +41,10 @@
 
 <p>The notice is:</p>
 
-<p>&quot;Copyright &copy; 2018, 2020 Eclipse Foundation. This software or
+<p>&quot;Copyright &copy; 2018, 2022 Eclipse Foundation. This software or
   document includes material copied from or derived from
   Jakarta ® Server Pages
-  https://jakarta.ee/specifications/pages/3.1/&quot;</p>
+  https://jakarta.ee/specifications/pages/4.0/&quot;</p>
 
 <h2>Disclaimers</h2>
 

--- a/api/src/main/javadoc/jakarta/servlet/jsp/package.html
+++ b/api/src/main/javadoc/jakarta/servlet/jsp/package.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
     Copyright 2004 The Apache Software Foundation
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@
 <head>
 </head>
 <body bgcolor="white">
-Classes and interfaces for the Core JSP 3.1 API.
+Classes and interfaces for the Core JSP 4.0 API.
 
 <p>
 References in this document to JSP refer to the Jakarta Server Pages

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates and others.
     All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -29,7 +29,7 @@
 
     <groupId>jakarta.servlet.jsp</groupId>
     <artifactId>jsp-parent</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Server Pages API</name>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation.
+    Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.servlet.jsp</groupId>
     <artifactId>server-pages-spec</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Server Pages Specification</name>

--- a/spec/src/main/asciidoc/ServerPages.adoc
+++ b/spec/src/main/asciidoc/ServerPages.adoc
@@ -7,7 +7,7 @@
 :jsp-chapter: 0
 
 :sectnums!:
-== Jakarta Server Pages Specification, Version 3.1
+== Jakarta Server Pages Specification, Version 4.0
 
 Copyright (c) 2013, 2022 Oracle and/or its affiliates and others.
 All rights reserved.
@@ -24,13 +24,13 @@ Comments to: jsp-dev@eclipse.org
 === Preface
 
 This is the Jakarta Server Pages specification
-version 3.1, developed by the Jakarta Server Pages Team under the Eclipse
+version 4.0, developed by the Jakarta Server Pages Team under the Eclipse
 Foundation Specification Process. References in this document to JSP refer
 to Jakarta Server Pages unless otherwise noted.
 
 ==== Who Should Read This Document
 
-This document is the authoritative JSP 3.1
+This document is the authoritative JSP 4.0
 specification. It is intended to provide requirements for
 implementations of JSP page processing, and support by web containers in
 web servers and application servers. As an authoritative document, it
@@ -321,7 +321,7 @@ this class of user:
 * Appendices <<Packaging JSP Pages>>, <<Changes>>, and <<Glossary>>
 
 Advanced page authors may also wish to look at the Javadoc for the
-`jakarta.servlet.jsp` package and the XML schema for the JSP 3.1
+`jakarta.servlet.jsp` package and the XML schema for the JSP 4.0
 deployment descriptor.
 
 ===== Tag Library Developers
@@ -401,7 +401,7 @@ The chapters of this part are:
 == Core Syntax and Semantics{counter2:jsp-chapter}
 
 This chapter describes the core syntax
-and semantics for the Jakarta Server Pages 3.1 specification (JSP 3.1).
+and semantics for the Jakarta Server Pages 4.0 specification (JSP 4.0).
 
 === What Is a JSP Page
 
@@ -622,7 +622,7 @@ time.
 ===== JSP Page Packaging
 
 When a JSP page implementation class depends
-on support classes in addition to the JSP 3.1 and Servlet 6.0 classes,
+on support classes in addition to the JSP 4.0 and Servlet 6.0 classes,
 the support classes are included in the packaged WAR, as defined in the
 Servlet 6.0 specification, for portability across JSP containers.
 
@@ -642,7 +642,7 @@ implementation class for that page.
 In the past debugging tools provided by
 development environments have lacked a standard format for conveying
 source map information allowing the debugger of one vendor to be used
-with the JSP container of another. JSP 3.1 containers must
+with the JSP container of another. JSP 4.0 containers must
 support the Jakarta Debugging Support for Other Languages Specification.
 Details can be found in <<Debugging Requirements>>.
 
@@ -674,7 +674,7 @@ servlets, and other resources used in the web application. The
 deployment descriptor is described in detail in the Servlet 6.0
 specification.
 
-JSP 3.1 requires that these resources be
+JSP 4.0 requires that these resources be
 implicitly associated with and accessible through a unique
 `ServletContext` instance available as the implicit `application` object
 (see <<Objects>>).
@@ -688,7 +688,7 @@ semantics of the following elements:
 * The `jsp:include` action element (see <<jsp:include>>).
 * The `jsp:forward` action (see<<jsp:forward>>).
 
-JSP 3.1 supports portable packaging and
+JSP 4.0 supports portable packaging and
 deployment of web applications through the Servlet 6.0 specification.
 The Jakarta Server Pages specification inherits from the servlet
 specification the concepts of applications, `ServletContexts`,
@@ -2181,7 +2181,7 @@ written to it will be passed directly through to the `ServletResponse`
 output stream.
 
 A JSP page can also describe what should
-happen when some specific events occur. In JSP 3.1, the only events that
+happen when some specific events occur. In JSP 4.0, the only events that
 can be described are the initialization and the destruction of the page.
 These events are described using “well-known method names” in
 declaration elements. (See <<JSP Container>>).
@@ -2531,7 +2531,7 @@ The details of the attributes are as follows:
 the scriptlets, expression scriptlets, and declarations within the body
 of the translation unit (the JSP page and any files included using the
 `include` directive below). +
-In JSP 3.1, the only defined and required
+In JSP 4.0, the only defined and required
 scripting language value for this attribute is `java` (all lowercase,
 case-sensitive). +
 This specification only describes the
@@ -2884,7 +2884,7 @@ for mixed syntax includes are described in
 
 A JSP container can include a mechanism for
 being notified if an included file changes, so the container can
-recompile the JSP page. However, the JSP 3.1 specification does not have
+recompile the JSP page. However, the JSP 4.0 specification does not have
 a way of directing the JSP container that included files have changed.
 
 The `<jsp:directive.include>` element (<<The jsp:directive.include Element>>)
@@ -2927,13 +2927,13 @@ The semantics for mixed syntax includes are described in
 ==== Including Data in JSP Pages
 
 Including data is a significant part of the
-tasks in a JSP page. Accordingly, the JSP 3.1 specification has two
+tasks in a JSP page. Accordingly, the JSP 4.0 specification has two
 include mechanisms suited to different tasks. A summary of their
-semantics is shown in <<_Summary_of_Include_Mechanisms_in_JSP_3.1>>.
+semantics is shown in <<_Summary_of_Include_Mechanisms_in_JSP_4.0>>.
 
 [caption='*Table JSP.{jsp-chapter}-{counter:table-number}* ']
-[[_Summary_of_Include_Mechanisms_in_JSP_3.1]]
-.Summary of Include Mechanisms in JSP 3.1
+[[_Summary_of_Include_Mechanisms_in_JSP_4.0]]
+.Summary of Include Mechanisms in JSP 4.0
 [cols="28,15,12,25,20",options="header"]
 |===
 
@@ -3053,7 +3053,7 @@ element in the web.xml deployment descriptor (see
 There are three other classes of scripting
 elements: declarations, scriptlets and expressions. The scripting
 language used in the current page is given by the value of the
-`language` directive (see <<The `page` Directive>>). In JSP 3.1, the only
+`language` directive (see <<The `page` Directive>>). In JSP 4.0, the only
 value defined is `java`.
 
 Declarations are used to declare scripting
@@ -3283,7 +3283,7 @@ may be applicable; the rules for them are described in
 <<Type Conversions>>.
 
 Many values are fixed translation-time
-values, but JSP 3.1 also provides a mechanism for describing values that
+values, but JSP 4.0 also provides a mechanism for describing values that
 are computed at request time, the rules are described in
 <<Request Time Attribute Values>>.
 
@@ -3449,7 +3449,7 @@ document must be followed.
 == Expression Language{counter2:jsp-chapter}
 
 Please consult the Jakarta Expression Language 5.0 specification document
-for details on the Expression Language supported by JSP 3.1.
+for details on the Expression Language supported by JSP 4.0.
 
 The addition of the EL to the JSP technology
 facilitates the writing of scriptless JSP pages. These pages can
@@ -3461,7 +3461,7 @@ The EL is available in attribute values for
 standard and custom actions and within template text.
 
 This chapter describes how the expression
-language is integrated within the JSP 3.1 environment.
+language is integrated within the JSP 4.0 environment.
 
 === Syntax of Expressions in JSP Pages: ${} vs #{}
 
@@ -3995,7 +3995,7 @@ This chapter describes the JSP
 configuration information, which is specified in the Web Application
 Deployment Descriptor in `WEB-INF/web.xml`. For Servlet 6.0, the Web
 Application Deployment Descriptor is defined using XML Schema, and
-imports the elements described in the XML Schema for JSP 3.1 Deployment
+imports the elements described in the XML Schema for JSP 4.0 Deployment
 Descriptor. See the XML Schema for the details on how to specify JSP
 configuration information in a Web Application.
 
@@ -4844,7 +4844,7 @@ Combinations of these approaches also make sense.
 == Standard Actions{counter2:jsp-chapter}
 
 This chapter describes the standard
-actions of Jakarta Server Pages 3.1 (JSP 3.1). Standard actions are
+actions of Jakarta Server Pages 4.0 (JSP 4.0). Standard actions are
 represented using XML elements with a prefix of `jsp` (though that
 prefix can be redefined in the XML syntax). A translation error will
 result if the JSP prefix is used for an element that is not a standard
@@ -5353,7 +5353,7 @@ the property is obtained.
 
 A `<jsp:include \.../>` action provides for
 the inclusion of static and dynamic resources in the same context as the
-current page. See <<Summary of Include Mechanisms in JSP 3.1>> for a summary of include facilities.
+current page. See <<Summary of Include Mechanisms in JSP 4.0>> for a summary of include facilities.
 
 Inclusion is into the current value of `out`. The resource is specified
 using a `relativeURLspec` that is
@@ -6064,7 +6064,7 @@ has a special meaning when used in the body of `<jsp:element>`. See
 
 |`name`
 |(required) The value of name is that of the
-element generated. The name can be a QName; JSP 3.1 places no
+element generated. The name can be a QName; JSP 4.0 places no
 constraints on this value: it is accepted as is. A request-time
 attribute value may be used for this attribute.
 
@@ -6168,7 +6168,7 @@ The `jsp:output` action can only be used in
 JSP documents and in tag files in XML syntax, and a translation error
 must result if used in a standard syntax JSP or tag file. This action is
 used to modify some properties of the output of a JSP document or a tag
-file. In JSP 3.1 there are four properties that can be specified, all of
+file. In JSP 4.0 there are four properties that can be specified, all of
 which affect the output of the XML prolog.
 
 The `omit-xml-declaration` property allows
@@ -6479,7 +6479,7 @@ The _XML view of a JSP page_ is an XML
 document that is derived from the JSP page following a mapping defined
 later in this chapter. The XML view of a JSP page is intended to be used
 for validating the JSP page against some description of the set of valid
-pages. Validation of the JSP page is supported in the JSP 3.1
+pages. Validation of the JSP page is supported in the JSP 4.0
 specification through a `TagLibraryValidator` class associated with a
 tag library. The validator class acts on a PageData object that
 represents the XML view of the JSP page (see, for example,
@@ -6536,12 +6536,12 @@ See <<Tag Files in XML Syntax>> for details on identifying tag files in XML synt
 
 A JSP document may or not have a `<jsp:root>`
 as its top element; `<jsp:root>` was mandatory in JSP 1.2, but we expect
-most JSP documents in JSP 3.1 not to use it.
+most JSP documents in JSP 4.0 not to use it.
 
 JSP documents identify standard actions
 through the use of a well-defined URI in its namespace; although in this
 chapter the prefix `jsp` is used for the standard actions, any prefix is
-valid as long as the correct URI identifying JSP 3.1 standard actions is
+valid as long as the correct URI identifying JSP 4.0 standard actions is
 used. Custom actions are identified using the URI that identifies their
 tag library; `taglib` directives are not required and cannot appear in a
 JSP document.
@@ -6659,7 +6659,7 @@ must be validated by the container in the translation phase. Validation
 errors must be handled the same way as any other translation phase
 errors, as described in <<Translation Time Processing Errors>>.
 
-JSP 3.1 requires only DTD validation for JSP
+JSP 4.0 requires only DTD validation for JSP
 Documents; containers should not perform validation based on other types
 of schemas, such as XML schema.
 
@@ -6804,7 +6804,7 @@ jsp:root is the version of the JSP specification used:
 
 |`version`
 |(required) The version of the JSP specification used in this page.
-Valid values are "1.2", "2.0", "2.1", "2.2", "2.3", "3.0" and "3.1".
+Valid values are "1.2", "2.0", "2.1", "2.2", "2.3", "3.0", "3.1" and "4.0".
 It is a translation error if the container does not support the specified version.
 
 |===
@@ -7087,7 +7087,7 @@ custom action, then the elements so effected would be interpreted as
 invocations on custom actions or tags.
 
 Although the JSP container understands that
-this document is a namespace-aware document, the JSP 3.1 container does
+this document is a namespace-aware document, t4.0JSP 3.1 container does
 not really understand that the generated content is a well-formed XML
 document and, as the next example shows, a JSP document can generate
 other types of content.
@@ -7242,7 +7242,7 @@ versions of the JSP specification.
 
 ==== Generating XML Content Natively
 
-All JSP 3.1 content is textual, even when
+A4.0JSP 3.1 content is textual, even when
 using JSP documents to generate XML content. This is quite acceptable,
 and even ideal, for some applications, but in some other applications
 XML documents are the main data type being manipulated. For example, the
@@ -8344,7 +8344,7 @@ development group may want to constrain the way some features are used.
 
 Validation can be done either at
 translation-time or at request-time. In general translation-time
-validation provides a better user experience, and the JSP 3.1
+validation provides a better user experience, and t4.0JSP 3.1
 specification provides a very flexible translation-time validation
 mechanism.
 
@@ -10628,7 +10628,7 @@ from the JSP page implementation object to the client.
 The JSP page describes how to create a
 response object from a request object for a given protocol, possibly
 creating and/or using some other objects in the process . A JSP page may
-also indicate how some events are to be handled. In JSP 3.1 only `init`
+also indicate how some events are to be handled. 4.0JSP 3.1 only `init`
 and `destroy` events are allowed events.
 
 The JSP container must render a JSP page for the HTTP methods GET and POST
@@ -10669,7 +10669,7 @@ in <<Scripting>>.
 
 The contract also describes how a JSP author
 can indicate what actions will be taken when the `init` and `destroy`
-methods of the page implementation occur. In JSP 3.1 this is done by
+methods of the page implementation occur. 4.0JSP 3.1 this is done by
 defining methods with the names `jspInit` and `jspDestroy` in a
 declaration scripting element in the JSP page. The `jspInit` method, if
 present, will be called to prepare the page before the first request is
@@ -11029,7 +11029,7 @@ can still be used in a scriptlet in a `.jsp` file, by invoking
 === Precompilation
 
 A JSP page that is using the HTTP protocol
-will receive HTTP requests. JSP 3.1 compliant containers must support a
+will receive HTTP request4.0JSP 3.1 compliant containers must support a
 simple precompilation protocol, as well as some basic reserved parameter
 names. Note that the precompilation protocol is related but not the same
 as the notion of compiling a JSP page into a `Servlet` class
@@ -11082,9 +11082,7 @@ error; 500 (Server error).
 The Jakarta Debugging Support for Other Languages specification provides
 the JSP Compiler with a standard format to convey source map debugging
 information to tools such as debuggers. See
-`https://jakarta.ee/specifications/debugging/2.0/` for details.
-
-JSP 3.1 containers are required to provide debugging support for JSP pages
+`https://jakarta.ee/specifications/debugging/2.0/` for details4.0JSP 3.1 containers are required to provide debugging support for JSP pages
 and tag files written in either standard or XML syntax.
 
 The JSP compiler must produce `.class` files
@@ -11230,13 +11228,13 @@ This appendix shows two simple examples
 of packaging a JSP page into a WAR for delivery into a Web container. In
 the first example, the JSP page is delivered in source form. This is
 likely to be the most common example. In the second example the JSP page
-is compiled into a servlet that uses only Servlet 6.0 and JSP 3.1 API
+is compiled into a servlet that uses only Servlet 6.0 a4.0JSP 3.1 API
 calls; the servlet is then packaged into a WAR with a deployment
 descriptor such that it looks as the original JSP page to any client.
 
 This appendix is non normative. Actually,
 strictly speaking, the appendix relates more to the Servlet 6.0
-capabilities than to the JSP 3.1 capabilities. The appendix is included
+capabilities than to t4.0JSP 3.1 capabilities. The appendix is included
 here as this is a feature that JSP page authors and JSP page authoring
 tools are interested in.
 
@@ -11279,7 +11277,7 @@ compile the JSP page into a servlet class to run in a JSP container.
 
 The JSP page is compiled into a servlet with
 some implementation dependent name `com.acme._jsp_HelloWorld_XXX_Impl`.
-The servlet code only depends on the JSP 3.1 and Servlet 6.0 APIs, as
+The servlet code only depends on t4.0JSP 3.1 and Servlet 6.0 APIs, as
 follows:
 
 [source,java]
@@ -11421,7 +11419,7 @@ standard syntax.
 
 . Reset the file.
 
-. If the file is a JSP page in standard syntax:
+. If the file is a JSP page in standard syn4.0:
 +
 3.1 If the file is not preceded by a BOM:
 +
@@ -11546,6 +11544,10 @@ described in appendix F.1 of the XML 1.0 specification.
 
 This appendix lists the changes in the
 Jakarta Server Pages specification. This appendix is non-normative.
+
+=== Changes between JSP 4.0 and JSP 3.1
+
+* TBD
 
 === Changes between JSP 3.1 and JSP 3.0
 

--- a/spec/src/main/asciidoc/license-efsl.adoc
+++ b/spec/src/main/asciidoc/license-efsl.adoc
@@ -52,10 +52,10 @@ specification is expressly prohibited.
 
 The notice is:
 
-"Copyright © 2018, 2020 Eclipse Foundation. This software or document
+"Copyright © 2018, 2022 Eclipse Foundation. This software or document
 includes material copied from or derived from
 Jakarta ® Server Pages
-https://jakarta.ee/specifications/pages/3.1/[https://jakarta.ee/specifications/pages/3.1/]"
+https://jakarta.ee/specifications/pages/4.0/[https://jakarta.ee/specifications/pages/4.0/]"
 
 ==== Disclaimers
 


### PR DESCRIPTION
The expectation is that some deprecated API elements will be removed in the next release requiring a major version bump.