### PR TITLE
Remove ErrorData constructor deprecation

### DIFF
--- a/api/src/main/java/jakarta/servlet/jsp/ErrorData.java
+++ b/api/src/main/java/jakarta/servlet/jsp/ErrorData.java
@@ -41,10 +41,7 @@ public final class ErrorData {
      * @param statusCode  The status code of the error
      * @param uri         The request URI
      * @param servletName The name of the servlet invoked
-     * 
-     * @deprecated Use {@link ErrorData#ErrorData(Throwable, int, String, String, String)}
      */
-    @Deprecated(since = "4.0", forRemoval = true)
     public ErrorData(Throwable throwable, int statusCode, String uri, String servletName) {
         this(throwable, statusCode, uri, servletName, null);
     }


### PR DESCRIPTION
Originally deprecated here: https://github.com/jakartaee/pages/pull/238

Discussion for removal of the deprecation on the mailing list here: https://www.eclipse.org/lists/jsp-dev/msg00351.html