### PR TITLE
Update minimum Java version to 17

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -144,8 +144,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                     <compilerArgument>-Xlint:unchecked</compilerArgument>
                 </configuration>
             </plugin>

--- a/spec/src/main/asciidoc/ServerPages.adoc
+++ b/spec/src/main/asciidoc/ServerPages.adoc
@@ -9,7 +9,7 @@
 :sectnums!:
 == Jakarta Server Pages Specification, Version 4.0
 
-Copyright (c) 2013, 2022 Oracle and/or its affiliates and others.
+Copyright (c) 2013, 2023 Oracle and/or its affiliates and others.
 All rights reserved.
 
 Eclipse is a registered trademark of the Eclipse Foundation. Jakarta
@@ -11429,6 +11429,8 @@ This appendix lists the changes in the
 Jakarta Server Pages specification. This appendix is non-normative.
 
 === Changes between JSP 4.0 and JSP 3.1
+
+* Update the minimum Java version to Java 17.
 
 * Remove the methods that implemented `ELResolver.getFeatureDescriptors()` as
   those methods have been removed as of EL 6.0.


### PR DESCRIPTION
This is primarily driven by addition of Record support in EL 6.0