### PR TITLE
Remove dependency on EL TCK

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -67,11 +67,6 @@
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>
-            <artifactId>jakarta-expression-language-tck</artifactId>
-            <version>${jakarta.el-api.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
             <version>2.2</version>
         </dependency>

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/arrayelresolver/ArrayELResolverTag.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/arrayelresolver/ArrayELResolverTag.java
@@ -19,7 +19,7 @@ package ee.jakarta.tck.pages.api.jakarta_el.arrayelresolver;
 
 import java.io.IOException;
 
-import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
+import ee.jakarta.tck.pages.common.el.resolver.ResolverTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 
 import jakarta.el.ArrayELResolver;
@@ -30,6 +30,7 @@ import jakarta.servlet.jsp.tagext.SimpleTagSupport;
 
 public class ArrayELResolverTag extends SimpleTagSupport {
 
+  @Override
   public void doTag() throws JspException, IOException {
 
     StringBuffer buf = new StringBuffer();

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/arrayelresolver/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/arrayelresolver/URLClientIT.java
@@ -21,12 +21,10 @@
 
 package ee.jakarta.tck.pages.api.jakarta_el.arrayelresolver;
 
-import java.io.IOException;
-
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
+import ee.jakarta.tck.pages.common.el.resolver.BarELResolver;
+import ee.jakarta.tck.pages.common.el.resolver.ResolverTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
-import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
-import com.sun.ts.tests.el.common.api.resolver.BarELResolver;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
@@ -47,7 +45,7 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_arrayelresolver_web.war");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/beanelresolver/BeanELResolverTag.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/beanelresolver/BeanELResolverTag.java
@@ -19,7 +19,7 @@ package ee.jakarta.tck.pages.api.jakarta_el.beanelresolver;
 
 import java.io.IOException;
 
-import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
+import ee.jakarta.tck.pages.common.el.resolver.ResolverTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 
 import jakarta.el.BeanELResolver;
@@ -30,6 +30,7 @@ import jakarta.servlet.jsp.tagext.SimpleTagSupport;
 
 public class BeanELResolverTag extends SimpleTagSupport {
 
+  @Override
   public void doTag() throws JspException, IOException {
 
     StringBuffer buf = new StringBuffer();

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/beanelresolver/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/beanelresolver/URLClientIT.java
@@ -21,13 +21,10 @@
 
 package ee.jakarta.tck.pages.api.jakarta_el.beanelresolver;
 
-import java.io.IOException;
-
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
-
+import ee.jakarta.tck.pages.common.el.resolver.BarELResolver;
+import ee.jakarta.tck.pages.common.el.resolver.ResolverTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
-import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
-import com.sun.ts.tests.el.common.api.resolver.BarELResolver;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
@@ -47,7 +44,7 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_beanelresolver_web.war");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/compelresolver/CompositeELResolverTag.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/compelresolver/CompositeELResolverTag.java
@@ -19,7 +19,7 @@ package ee.jakarta.tck.pages.api.jakarta_el.compelresolver;
 
 import java.io.IOException;
 
-import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
+import ee.jakarta.tck.pages.common.el.resolver.ResolverTest;
 import ee.jakarta.tck.pages.common.util.InstallCompositeELResolverListener;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 
@@ -31,6 +31,7 @@ import jakarta.servlet.jsp.tagext.SimpleTagSupport;
 
 public class CompositeELResolverTag extends SimpleTagSupport {
 
+  @Override
   public void doTag() throws JspException, IOException {
 
     StringBuffer buf = new StringBuffer("");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/compelresolver/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/compelresolver/URLClientIT.java
@@ -21,13 +21,11 @@
 
 package ee.jakarta.tck.pages.api.jakarta_el.compelresolver;
 
-import java.io.IOException;
-
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
+import ee.jakarta.tck.pages.common.el.resolver.BarELResolver;
+import ee.jakarta.tck.pages.common.el.resolver.ResolverTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 import ee.jakarta.tck.pages.common.util.InstallCompositeELResolverListener;
-import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
-import com.sun.ts.tests.el.common.api.resolver.BarELResolver;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
@@ -50,7 +48,7 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_compelresolver_web.war");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/createmethexpr/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/createmethexpr/URLClientIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2007, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,12 +16,10 @@
  */
 
 /*
- * @(#)URLClient.java	
+ * @(#)URLClient.java
  */
 
 package ee.jakarta.tck.pages.api.jakarta_el.createmethexpr;
-
-import java.io.IOException;
 
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
@@ -46,7 +45,7 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_createmethexpr_web.war");
@@ -59,16 +58,16 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
 
-  
+
   /* Run tests */
 
   // ============================================ Tests ======
 
   /*
    * @testName: createMethodExpressionTest
-   * 
+   *
    * @assertion_ids: EL:JAVADOC:62
-   * 
+   *
    * @test_Strategy: Validate the behavior of
    * ExpressionFactory.createMethodExpression().
    */

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/createvalexpr/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/createvalexpr/URLClientIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2007, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,15 +16,13 @@
  */
 
 /*
- * @(#)URLClient.java	
+ * @(#)URLClient.java
  */
 
 package ee.jakarta.tck.pages.api.jakarta_el.createvalexpr;
 
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
-
-import java.io.IOException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
@@ -46,7 +45,7 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_createvalexpr_web.war");
@@ -59,16 +58,16 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
 
-  
+
   /* Run tests */
 
   // ============================================ Tests ======
 
   /*
    * @testName: createValueExpressionTest
-   * 
+   *
    * @assertion_ids: EL:JAVADOC:63
-   * 
+   *
    * @test_Strategy: Validate the behavior of
    * ExpressionFactory.createValueExpression().
    */

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/elresolver/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/elresolver/URLClientIT.java
@@ -22,12 +22,9 @@
 package ee.jakarta.tck.pages.api.jakarta_el.elresolver;
 
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
+import ee.jakarta.tck.pages.common.el.resolver.BarELResolver;
+import ee.jakarta.tck.pages.common.el.resolver.ResolverTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
-import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
-import com.sun.ts.tests.el.common.api.resolver.BarELResolver;
-
-import java.io.IOException;
-
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
@@ -51,7 +48,7 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_elresolver_web.war");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/listelresolver/ListELResolverTag.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/listelresolver/ListELResolverTag.java
@@ -20,7 +20,7 @@ package ee.jakarta.tck.pages.api.jakarta_el.listelresolver;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
+import ee.jakarta.tck.pages.common.el.resolver.ResolverTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 
 import jakarta.el.ELContext;
@@ -31,10 +31,11 @@ import jakarta.servlet.jsp.tagext.SimpleTagSupport;
 
 public class ListELResolverTag extends SimpleTagSupport {
 
+  @Override
   public void doTag() throws JspException, IOException {
 
     StringBuffer buf = new StringBuffer();
-    ArrayList<String> superheroes = new ArrayList<String>();
+    ArrayList<String> superheroes = new ArrayList<>();
     superheroes.add("Batman");
     superheroes.add("Superman");
     superheroes.add("Spiderman");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/listelresolver/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/listelresolver/URLClientIT.java
@@ -22,11 +22,9 @@
 package ee.jakarta.tck.pages.api.jakarta_el.listelresolver;
 
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
+import ee.jakarta.tck.pages.common.el.resolver.BarELResolver;
+import ee.jakarta.tck.pages.common.el.resolver.ResolverTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
-import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
-import com.sun.ts.tests.el.common.api.resolver.BarELResolver;
-
-import java.io.IOException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
@@ -49,7 +47,7 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_listelresolver_web.war");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/mapelresolver/MapELResolverTag.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/mapelresolver/MapELResolverTag.java
@@ -20,7 +20,7 @@ package ee.jakarta.tck.pages.api.jakarta_el.mapelresolver;
 import java.io.IOException;
 import java.util.HashMap;
 
-import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
+import ee.jakarta.tck.pages.common.el.resolver.ResolverTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 
 import jakarta.el.ELContext;
@@ -31,10 +31,11 @@ import jakarta.servlet.jsp.tagext.SimpleTagSupport;
 
 public class MapELResolverTag extends SimpleTagSupport {
 
+  @Override
   public void doTag() throws JspException, IOException {
 
     StringBuffer buf = new StringBuffer();
-    HashMap sportstars = new HashMap();
+    HashMap<String,String> sportstars = new HashMap<>();
     sportstars.put("baseball", "Barry Bonds");
     sportstars.put("football", "Joe Montana");
     sportstars.put("basketball", "Michael Jordan");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/mapelresolver/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/mapelresolver/URLClientIT.java
@@ -22,11 +22,9 @@
 package ee.jakarta.tck.pages.api.jakarta_el.mapelresolver;
 
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
+import ee.jakarta.tck.pages.common.el.resolver.BarELResolver;
+import ee.jakarta.tck.pages.common.el.resolver.ResolverTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
-import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
-import com.sun.ts.tests.el.common.api.resolver.BarELResolver;
-
-import java.io.IOException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
@@ -49,7 +47,7 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_mapelresolver_web.war");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/methodinfo/MethodInfoTag.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/methodinfo/MethodInfoTag.java
@@ -19,7 +19,7 @@ package ee.jakarta.tck.pages.api.jakarta_el.methodinfo;
 
 import java.io.IOException;
 
-import com.sun.ts.tests.el.common.api.expression.ExpressionTest;
+import ee.jakarta.tck.pages.common.el.expression.ExpressionTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 
 import jakarta.el.ELContext;
@@ -37,6 +37,7 @@ public class MethodInfoTag extends SimpleTagSupport {
     this.mexp = mexp;
   }
 
+  @Override
   public void doTag() throws JspException, IOException {
 
     JspWriter out = getJspContext().getOut();
@@ -45,7 +46,7 @@ public class MethodInfoTag extends SimpleTagSupport {
 
     try {
       MethodInfo minfo = mexp.getMethodInfo(elContext);
-      Class[] paramTypes = { Object.class };
+      Class<?>[] paramTypes = { Object.class };
       boolean pass = ExpressionTest.testMethodInfo(minfo, "add", boolean.class,
           1, paramTypes, buf);
 

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/methodinfo/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/methodinfo/URLClientIT.java
@@ -22,11 +22,9 @@
 package ee.jakarta.tck.pages.api.jakarta_el.methodinfo;
 
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
+import ee.jakarta.tck.pages.common.el.expression.ExpressionTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 import ee.jakarta.tck.pages.common.tags.tck.SetTag;
-import com.sun.ts.tests.el.common.api.expression.ExpressionTest;
-
-import java.io.IOException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
@@ -49,7 +47,7 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_methodinfo_web.war");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/resourcebundleelresolver/ResourceBundleELResolverTag.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/resourcebundleelresolver/ResourceBundleELResolverTag.java
@@ -22,7 +22,7 @@ import java.util.Enumeration;
 import java.util.ResourceBundle;
 import java.util.StringTokenizer;
 
-import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
+import ee.jakarta.tck.pages.common.el.resolver.ResolverTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 
 import jakarta.el.ELContext;
@@ -33,6 +33,7 @@ import jakarta.servlet.jsp.tagext.SimpleTagSupport;
 
 public class ResourceBundleELResolverTag extends SimpleTagSupport {
 
+  @Override
   public void doTag() throws JspException, IOException {
 
     StringBuffer buf = new StringBuffer();
@@ -56,6 +57,7 @@ public class ResourceBundleELResolverTag extends SimpleTagSupport {
 
   static class MyResources extends ResourceBundle {
 
+    @Override
     public Object handleGetObject(String key) {
       if (key.equals("okKey"))
         return "Ok";
@@ -64,6 +66,7 @@ public class ResourceBundleELResolverTag extends SimpleTagSupport {
       return null;
     }
 
+    @Override
     public Enumeration getKeys() {
       return new StringTokenizer("okKey cancelKey");
     }

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/resourcebundleelresolver/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/resourcebundleelresolver/URLClientIT.java
@@ -22,11 +22,9 @@
 package ee.jakarta.tck.pages.api.jakarta_el.resourcebundleelresolver;
 
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
+import ee.jakarta.tck.pages.common.el.resolver.BarELResolver;
+import ee.jakarta.tck.pages.common.el.resolver.ResolverTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
-import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
-import com.sun.ts.tests.el.common.api.resolver.BarELResolver;
-
-import java.io.IOException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
@@ -49,7 +47,7 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_resourcebundleelresolver_web.war");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/valexpression/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/valexpression/URLClientIT.java
@@ -22,11 +22,9 @@
 package ee.jakarta.tck.pages.api.jakarta_el.valexpression;
 
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
+import ee.jakarta.tck.pages.common.el.expression.ExpressionTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 import ee.jakarta.tck.pages.common.tags.tck.SetTag;
-import com.sun.ts.tests.el.common.api.expression.ExpressionTest;
-
-import java.io.IOException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
@@ -49,7 +47,7 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_valexpr_web.war");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/valexpression/ValueExpressionTag.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_el/valexpression/ValueExpressionTag.java
@@ -19,7 +19,7 @@ package ee.jakarta.tck.pages.api.jakarta_el.valexpression;
 
 import java.io.IOException;
 
-import com.sun.ts.tests.el.common.api.expression.ExpressionTest;
+import ee.jakarta.tck.pages.common.el.expression.ExpressionTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 
 import jakarta.el.ELContext;
@@ -42,7 +42,8 @@ public class ValueExpressionTag extends SimpleTagSupport {
     this.vexp = vexp;
   }
 
-  public void doTag() throws JspException, IOException {
+  @Override
+public void doTag() throws JspException, IOException {
 
     ELContext elContext = getJspContext().getELContext();
     StringBuffer buf = new StringBuffer("");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_servlet/jsp/el/implicitobjelresolver/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_servlet/jsp/el/implicitobjelresolver/URLClientIT.java
@@ -23,12 +23,11 @@ package ee.jakarta.tck.pages.api.jakarta_servlet.jsp.el.implicitobjelresolver;
 
 
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
+import ee.jakarta.tck.pages.common.el.resolver.BarELResolver;
+import ee.jakarta.tck.pages.common.el.resolver.ResolverTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 import ee.jakarta.tck.pages.common.util.JspResolverTest;
-import com.sun.ts.tests.el.common.api.resolver.BarELResolver;
-import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
 
-import java.io.IOException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -52,7 +51,7 @@ public class URLClientIT extends AbstractUrlClient {
     }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_implicitobjelresolver_web.war");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_servlet/jsp/el/scopedattrelresolver/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_servlet/jsp/el/scopedattrelresolver/URLClientIT.java
@@ -23,12 +23,11 @@ package ee.jakarta.tck.pages.api.jakarta_servlet.jsp.el.scopedattrelresolver;
 
 
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
+import ee.jakarta.tck.pages.common.el.resolver.BarELResolver;
+import ee.jakarta.tck.pages.common.el.resolver.ResolverTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 import ee.jakarta.tck.pages.common.util.JspResolverTest;
-import com.sun.ts.tests.el.common.api.resolver.BarELResolver;
-import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
 
-import java.io.IOException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -52,7 +51,7 @@ public class URLClientIT extends AbstractUrlClient {
     }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_scopedattrelresolver_web.war");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_servlet/jsp/tagext/simpletagsupport/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_servlet/jsp/tagext/simpletagsupport/URLClientIT.java
@@ -27,14 +27,10 @@ package ee.jakarta.tck.pages.api.jakarta_servlet.jsp.tagext.simpletagsupport;
 
 
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
+import ee.jakarta.tck.pages.common.el.expression.ExpressionTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 import ee.jakarta.tck.pages.common.tags.tck.SetTag;
-import com.sun.ts.tests.el.common.api.expression.ExpressionTest;
 
-/**
- * Test client for the default behavior of SimpleTagSupport.
- */
-import java.io.IOException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -58,7 +54,7 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_simtagsupport_web.war");

--- a/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_servlet/jsp/tagext/taginfo/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/api/jakarta_servlet/jsp/tagext/taginfo/URLClientIT.java
@@ -27,17 +27,11 @@ package ee.jakarta.tck.pages.api.jakarta_servlet.jsp.tagext.taginfo;
 
 
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
+import ee.jakarta.tck.pages.common.el.expression.ExpressionTest;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 import ee.jakarta.tck.pages.common.util.BaseTCKExtraInfo;
 import ee.jakarta.tck.pages.common.tags.tck.SimpleTag;
-import com.sun.ts.tests.el.common.api.expression.ExpressionTest;
 
-/**
- * Test client for TagInfo. Implementation note, all tests are performed within
- * a TagExtraInfo class. If the test fails, a translation error will be
- * generated and a ValidationMessage array will be returned.
- */
-import java.io.IOException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -60,7 +54,7 @@ public class URLClientIT extends AbstractUrlClient {
     }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_taginfo_web.war");

--- a/tck/src/main/java/ee/jakarta/tck/pages/common/el/Book.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/common/el/Book.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2007, 2025 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+/*
+ * Simple multi-member class to be used for type coercion tests.
+ */
+
+package ee.jakarta.tck.pages.common.el;
+
+public class Book {
+
+  private String title;
+
+  private String authors;
+
+  private String publisher;
+
+  private int year;
+
+  public Book(String title, String authors, String publisher, int year) {
+    this.title = title;
+    this.authors = authors;
+    this.publisher = publisher;
+    this.year = year;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getAuthors() {
+    return authors;
+  }
+
+  public String getPublisher() {
+    return publisher;
+  }
+
+  public int getYear() {
+    return year;
+  }
+
+  @Override
+  public String toString() {
+    return getTitle();
+  }
+}

--- a/tck/src/main/java/ee/jakarta/tck/pages/common/el/expression/ExpressionTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/common/el/expression/ExpressionTest.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2009, 2025 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package ee.jakarta.tck.pages.common.el.expression;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.annotation.Annotation;
+
+import jakarta.el.ELContext;
+import jakarta.el.Expression;
+import jakarta.el.MethodExpression;
+import jakarta.el.MethodInfo;
+import jakarta.el.MethodReference;
+import jakarta.el.PropertyNotWritableException;
+import jakarta.el.ValueExpression;
+
+public class ExpressionTest {
+
+  // Set New Line from system prop, if not defined used "\n as default."
+  private static final String NLINE = System.getProperty("line.separator",
+      "\n");
+
+  private ExpressionTest() {
+  }
+
+  public static boolean testMethodInfo(MethodInfo minfo, String expectedName,
+      Class<?> expectedReturnType, int expectedNumParams,
+      Class<?>[] expectedParamTypes, StringBuffer buf) {
+
+    boolean pass = true;
+    String name = minfo.getName();
+    Class<?> returnType = minfo.getReturnType();
+    Class<?>[] paramTypes = minfo.getParamTypes();
+    int numParams = paramTypes.length;
+
+    if (!name.equals(expectedName)) {
+      buf.append("Did not get expected method name." + NLINE);
+      buf.append("Expected name = " + expectedName + NLINE);
+      buf.append("Computed name = " + name + NLINE);
+      pass = false;
+    }
+    if (!returnType.equals(expectedReturnType)) {
+      buf.append("Did not get expected return type." + NLINE);
+      buf.append(
+          "Expected return type = " + expectedReturnType.getName() + NLINE);
+      buf.append("Computed return type = " + returnType.getName() + NLINE);
+      pass = false;
+    }
+    if (numParams != expectedNumParams) {
+      buf.append("Did not get expected number of parameters." + NLINE);
+      buf.append(
+          "Expected number of parameters = " + expectedNumParams + NLINE);
+      buf.append("Computed number of parameters = " + numParams + NLINE);
+      pass = false;
+    } else {
+      for (int i = 0; i < numParams; ++i) {
+        if (!(paramTypes[i].equals(expectedParamTypes[i]))) {
+          buf.append("Did not get expected parameter type." + NLINE);
+          buf.append("Expected parameter type = "
+              + expectedParamTypes[i].getName() + NLINE);
+          buf.append(
+              "Computed parameter type = " + paramTypes[i].getName() + NLINE);
+          pass = false;
+        }
+      }
+    }
+    return pass;
+  }
+
+  public static boolean testMethodReference(MethodReference mref,
+      Object expectedBase, MethodInfo expectedMethodInfo,
+      Class<?>[] expectedAnnotationTypes,
+      Object[] expectedParamValues, StringBuffer buf) {
+
+    boolean pass = true;
+
+    Object base = mref.getBase();
+    MethodInfo minfo = mref.getMethodInfo();
+    Annotation[] annotations = mref.getAnnotations();
+    Object[] parameterValues = mref.getEvaluatedParameters();
+
+    if (base == null) {
+      buf.append("Did not get expected base object." + NLINE);
+      buf.append("Expected base = " + expectedBase + NLINE);
+      buf.append("Computed name = null" + NLINE);
+      pass = false;
+    } else if (!base.equals(expectedBase)) {
+      buf.append("Did not get expected base object." + NLINE);
+      buf.append("Expected base = " + expectedBase + NLINE);
+      buf.append("Computed base = " + base + NLINE);
+      pass = false;
+    }
+
+    if (minfo == null) {
+      buf.append("Did not get expected MethodInfo object." + NLINE);
+      buf.append("Expected MethodInfo = " + expectedMethodInfo + NLINE);
+      buf.append("Computed MethodInfo = null" + NLINE);
+      pass = false;
+    } else if (!minfo.equals(expectedMethodInfo)) {
+      buf.append("Did not get expected base object." + NLINE);
+      buf.append("Expected MethodInfo = " + expectedMethodInfo + NLINE);
+      buf.append("Computed MethodInfo = " + minfo + NLINE);
+      pass = false;
+    }
+
+    if (annotations == null) {
+      buf.append("Did not get expected annotation array." + NLINE);
+      buf.append("Computed array was null" + NLINE);
+      pass = false;
+    } else if (annotations.length != expectedAnnotationTypes.length) {
+      buf.append("Did not get expected number of annotations." + NLINE);
+      buf.append("Expected annotation array length = " + expectedAnnotationTypes.length + NLINE);
+      buf.append("Computed annotation array length = " + annotations.length + NLINE);
+      pass = false;
+    } else {
+      for (int i = 0; i < annotations.length; i++) {
+        if (!annotations[i].annotationType().equals(expectedAnnotationTypes[i])) {
+          buf.append("Did not get expected annotation type for array index = " + i + NLINE);
+          buf.append("Expected type = " + expectedAnnotationTypes[i] + NLINE);
+          buf.append("Computed type = " + annotations[i].getClass() + NLINE);
+          pass = false;
+        }
+      }
+    }
+
+    if (parameterValues == null) {
+      buf.append("Did not get expected parameter value array." + NLINE);
+      buf.append("Computed array was null" + NLINE);
+      pass = false;
+    } else if (parameterValues.length != expectedParamValues.length) {
+      buf.append("Did not get expected number of parameter values." + NLINE);
+      buf.append("Expected annotation array length = " + expectedParamValues.length + NLINE);
+      buf.append("Computed annotation array length = " + parameterValues.length + NLINE);
+      pass = false;
+    } else {
+      for (int i = 0; i < parameterValues.length; i++) {
+        if (!parameterValues[i].equals(expectedParamValues[i])) {
+          buf.append("Did not get expected parameter value for array index = " + i + NLINE);
+          buf.append("Expected type = " + expectedParamValues[i] + NLINE);
+          buf.append("Computed type = " + parameterValues[i] + NLINE);
+          pass = false;
+        }
+      }
+    }
+
+    return pass;
+  }
+
+  public static boolean testValueExpression(ValueExpression vexp,
+      ELContext context, String exprStr, Class<?> expectedType,
+      Object expectedValue, boolean expectedReadOnly,
+      boolean expectedLiteralText, StringBuffer buf) {
+
+    boolean pass = true;
+
+    // getValue()
+    Object retrievedValue = vexp.getValue(context);
+    if (!retrievedValue.equals(expectedValue)) {
+      pass = false;
+      buf.append("getValue() does not return expected value" + NLINE);
+      buf.append("Expected value = " + expectedValue.toString() + NLINE);
+      buf.append("Computed value = " + retrievedValue.toString() + NLINE);
+    }
+
+    // setValue()
+    try {
+      vexp.setValue(context, "blue");
+      String newValue = (String) vexp.getValue(context);
+      if (expectedReadOnly) {
+        pass = false;
+        buf.append("setValue() succeeded on a read-only value" + NLINE);
+      } else if (!newValue.equals("blue")) {
+        pass = false;
+        buf.append(
+            "Did not get correct set value for " + "ValueExpression." + NLINE);
+        buf.append("Expected value = " + "blue" + NLINE);
+        buf.append("Computed value = " + newValue + NLINE);
+      }
+    } catch (PropertyNotWritableException pnwe) {
+      if (!expectedReadOnly) {
+        pass = false;
+        buf.append(
+            "setValue() threw " + "PropertyNotWritableException" + NLINE);
+        buf.append("on a writable value" + NLINE);
+      } else {
+        buf.append(
+            "PropertyNotWritableException caught as " + "expected." + NLINE);
+      }
+    }
+
+    // getType()
+    Class<?> type = vexp.getType(context);
+    String typeName = (type == null) ? "null" : type.getName();
+    buf.append("Type retrieved is " + typeName + NLINE);
+
+    // getExpectedType()
+    Class<?> retrievedType = vexp.getExpectedType();
+    if (!(retrievedType.equals(expectedType))) {
+      pass = false;
+      buf.append(
+          "getExpectedType() does not return expected " + "type" + NLINE);
+      buf.append("Expected type = " + expectedType.toString() + NLINE);
+      buf.append("Computed type = " + retrievedType.toString() + NLINE);
+    }
+
+    // isReadOnly()
+    if ((vexp.isReadOnly(context)) != expectedReadOnly) {
+      pass = false;
+      buf.append("isReadOnly() did not return " + expectedReadOnly + NLINE);
+    }
+
+    // isLiteralText()
+    if ((vexp.isLiteralText()) != expectedLiteralText) {
+      pass = false;
+      buf.append(
+          "isLiteralText() did not return " + expectedLiteralText + NLINE);
+    }
+
+    // getExpressionString()
+    String retrievedStr = vexp.getExpressionString();
+    if (!retrievedStr.equals(exprStr)) {
+      pass = false;
+      buf.append(
+          "getExpressionString() does not return expected " + "string" + NLINE);
+      buf.append("Expected string = " + exprStr + NLINE);
+      buf.append("Computed string = " + retrievedStr + NLINE);
+    }
+
+    return pass;
+  }
+
+  public static boolean testMethodExpression(MethodExpression mexp,
+      ELContext context, String exprStr, Object[] params,
+      Object expectedReturnValue, boolean expectedLiteralText,
+      StringBuffer buf) {
+
+    boolean pass = true;
+
+    // getMethodInfo()
+    try {
+      mexp.getMethodInfo(context);
+    } catch (Exception e) {
+      pass = false;
+      buf.append("getMethodInfo() threw an unexpected exception" + NLINE);
+      buf.append(e.getMessage() + NLINE);
+    }
+
+    // invoke()
+    try {
+      Object returnValue = mexp.invoke(context, params);
+      if (returnValue == null) {
+        if (expectedReturnValue != null) {
+          pass = false;
+          buf.append("invoke() unexpectedly returned null" + NLINE);
+        }
+      } else if (expectedReturnValue == null) {
+        pass = false;
+        buf.append(
+            "invoke() unexpectedly returned non-null " + "value" + NLINE);
+      } else if (!returnValue.equals(expectedReturnValue)) {
+        pass = false;
+        buf.append(
+            "invoke() returned an object of wrong type or " + "value" + NLINE);
+        buf.append(
+            "Expected return value: " + expectedReturnValue.toString() + NLINE);
+        buf.append("Computed return value: " + returnValue.toString() + NLINE);
+      }
+    } catch (Exception e) {
+      pass = false;
+      buf.append("invoke() threw an unexpected exception" + NLINE);
+      buf.append(e.getMessage() + NLINE);
+    }
+
+    // isLiteralText()
+    if ((mexp.isLiteralText()) != expectedLiteralText) {
+      pass = false;
+      buf.append(
+          "isLiteralText() did not return " + expectedLiteralText + NLINE);
+    }
+
+    // getExpressionString()
+    String retrievedStr = mexp.getExpressionString();
+    if (!retrievedStr.equals(exprStr)) {
+      pass = false;
+      buf.append(
+          "getExpressionString() does not return expected " + "string" + NLINE);
+      buf.append("Expected string = " + exprStr + NLINE);
+      buf.append("Computed string = " + retrievedStr + NLINE);
+    }
+
+    return pass;
+  }
+
+  public static boolean equalsTest(Expression exp1, Expression exp2,
+      StringBuffer buf) {
+
+    String e1str = exp1.getExpressionString();
+    String e2str = (exp2 == null) ? null : exp2.getExpressionString();
+
+    buf.append("Testing equality: " + e1str + " and " + e2str + NLINE);
+
+    if (!exp1.equals(exp2)) {
+      if (exp2 != null) {
+        buf.append("Expression " + e1str + " is not equal to " + "Expression "
+            + e2str + NLINE);
+      }
+      return false;
+    } else {
+      int hcode1 = exp1.hashCode();
+      @SuppressWarnings("null") // exp2 cannot be null here
+      int hcode2 = exp2.hashCode();
+
+      if (hcode1 != hcode2) {
+        buf.append("Expressions " + e1str + " and " + e2str + " are "
+            + "equal, but their" + NLINE);
+        buf.append("hashcodes aren't the same." + NLINE);
+        buf.append("Hashcode for " + e1str + ": " + hcode1 + NLINE);
+        buf.append("Hashcode for " + e2str + ": " + hcode2 + NLINE);
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  public static boolean expressionSerializableTest(Expression exp,
+      StringBuffer buf) {
+
+    ObjectOutputStream out = null;
+    ObjectInputStream in = null;
+    Expression desexp = null;
+    ByteArrayOutputStream bos = null;
+
+    // Serialize the Expression.
+    try {
+      bos = new ByteArrayOutputStream();
+      out = new ObjectOutputStream(bos);
+      out.writeObject(exp);
+    } catch (IOException ioe) {
+      buf.append(
+          "Failed to serialize the Expression!" + NLINE + ioe.toString());
+      return false;
+    } finally {
+      if (out != null) {
+        try {
+          out.close();
+        } catch (Exception close) {
+          // Do not fail the test if close does not happen.
+        }
+      }
+    }
+
+    // Deserialize the Expression.
+    try {
+      byte[] byteBuf = bos.toByteArray();
+      in = new ObjectInputStream(new ByteArrayInputStream(byteBuf));
+      desexp = (Expression) in.readObject();
+    } catch (IOException ioe) {
+      buf.append(
+          "Failed to deserialize the Expression!" + NLINE + ioe.toString());
+      return false;
+    } catch (ClassNotFoundException cnfe) {
+      buf.append("Could not find class of serialized Expression" + NLINE
+          + cnfe.toString());
+      return false;
+    } finally {
+      if (in != null) {
+        try {
+          in.close();
+        } catch (Exception close) {
+          // Do not fail the test if close does not happen.
+        }
+      }
+    }
+
+    // Test Expression After Serialization
+    if (!equalsTest(desexp, exp, buf)) {
+      buf.append("'getExpressionString' after serialization took " + "place."
+          + NLINE + "Expected: " + exp.getExpressionString() + NLINE
+          + "Received: " + desexp.getExpressionString() + NLINE);
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/tck/src/main/java/ee/jakarta/tck/pages/common/el/resolver/BarELResolver.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/common/el/resolver/BarELResolver.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.pages.common.el.resolver;
+
+import jakarta.el.ELContext;
+import jakarta.el.ELException;
+import jakarta.el.ELResolver;
+import jakarta.el.PropertyNotWritableException;
+
+public class BarELResolver extends ELResolver {
+
+  @Override
+  public Object getValue(ELContext context, Object base, Object property)
+      throws ELException {
+    Object result = null;
+    if (context == null)
+      throw new NullPointerException();
+
+    if (base == null) {
+      // Resolving first variable (e.g. ${Bar}).
+      // We only handle "Bar"
+      String propertyName = (String) property;
+      if (propertyName.equals("Bar")) {
+        result = "Foo";
+        context.setPropertyResolved(true);
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public Class<?> getType(ELContext context, Object base, Object property)
+      throws ELException {
+    if (context == null)
+      throw new NullPointerException();
+
+    if (base == null && property instanceof String
+        && property.toString().equals("Bar")) {
+      context.setPropertyResolved(true);
+    }
+
+    // we never set a value
+    return null;
+  }
+
+  @Override
+  public void setValue(ELContext context, Object base, Object property,
+
+      Object value) throws ELException {
+    if (context == null)
+      throw new NullPointerException();
+
+    if (base == null && property instanceof String
+        && property.toString().equals("Bar")) {
+      context.setPropertyResolved(true);
+      throw new PropertyNotWritableException();
+    }
+  }
+
+  @Override
+  public boolean isReadOnly(ELContext context, Object base, Object property)
+      throws ELException {
+    if (context == null)
+      throw new NullPointerException();
+
+    if (base == null && property instanceof String
+        && property.toString().equals("Bar")) {
+      context.setPropertyResolved(true);
+    }
+
+    return true;
+  }
+
+  @Override
+  public Class<?> getCommonPropertyType(ELContext context, Object base) {
+    if (context == null)
+      throw new NullPointerException();
+
+    if (base == null)
+      return String.class;
+    return null;
+  }
+}

--- a/tck/src/main/java/ee/jakarta/tck/pages/common/el/resolver/ResolverTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/common/el/resolver/ResolverTest.java
@@ -1,0 +1,542 @@
+/*
+ * Copyright (c) 2009, 2025 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package ee.jakarta.tck.pages.common.el.resolver;
+
+import java.util.Objects;
+
+import jakarta.el.BeanELResolver;
+import jakarta.el.CompositeELResolver;
+import jakarta.el.ELContext;
+import jakarta.el.ELResolver;
+import jakarta.el.MethodNotFoundException;
+import jakarta.el.PropertyNotFoundException;
+import jakarta.el.PropertyNotWritableException;
+
+public class ResolverTest {
+  private static final String NL = System.getProperty("line.separator", "\n");
+
+  /**
+   * Private as this class will only have static methods and members.
+   */
+  private ResolverTest() {
+  }
+
+  public static boolean testCompositeELResolver(ELContext elContext,
+      CompositeELResolver compResolver, StringBuffer buf) {
+
+    boolean pass = true;
+
+    // add()
+    BarELResolver barResolver = new BarELResolver();
+    try {
+      compResolver.add(barResolver);
+      buf.append("add() tested successfully" + NL);
+
+    } catch (Exception e) {
+      buf.append("add() method Test Failed");
+      pass = false;
+    }
+
+    // setValue()
+    elContext.setPropertyResolved(false);
+    compResolver.setValue(elContext, null, "Nothing", "rien");
+    if (!elContext.isPropertyResolved()) {
+      buf.append(
+          "setValue() tested successfully on non-existent " + "property" + NL);
+    } else {
+      buf.append("setValue() set property resolved on non-existent "
+          + "property" + NL);
+      pass = false;
+    }
+
+    elContext.setPropertyResolved(false);
+    try {
+      compResolver.setValue(elContext, null, "Bar", "rien");
+      pass = false;
+    } catch (PropertyNotWritableException pnwe) {
+      buf.append(
+          "setValue() tested successfully on non-writable " + "property" + NL);
+      buf.append("PropertyNotWritableException caught as expected" + NL);
+    }
+
+    // getValue()
+    elContext.setPropertyResolved(false);
+    String result = (String) compResolver.getValue(elContext, null, "Bar");
+    if (!elContext.isPropertyResolved()) {
+      buf.append("getValue() did not resolve" + NL);
+      pass = false;
+    } else if (!result.equals("Foo")) {
+      buf.append("Invalid value from BarELResolver: " + result + NL);
+      pass = false;
+    } else {
+      buf.append("getValue() tested successfully" + NL);
+    }
+
+    // getType()
+    elContext.setPropertyResolved(false);
+    Class<?> type = compResolver.getType(elContext, null, "Bar");
+    if (!elContext.isPropertyResolved()) {
+      buf.append("getType() did not resolve" + NL);
+      pass = false;
+    } else if (type != null) {
+      buf.append("getType() returns " + type.getName() + NL);
+      buf.append("not expected result for non-writable property" + NL);
+      pass = false;
+    } else {
+      buf.append("getType() returns null as expected for non-writable "
+          + "property" + NL);
+    }
+
+    // isReadOnly
+    elContext.setPropertyResolved(false);
+    boolean nonWritable = compResolver.isReadOnly(elContext, null, "Bar");
+    if (!elContext.isPropertyResolved()) {
+      buf.append("isReadOnly() did not resolve" + NL);
+      pass = false;
+    } else if (!nonWritable) {
+      buf.append("isReadOnly() did not return true" + NL);
+      pass = false;
+    } else {
+      buf.append("isReadOnly() returns true as expected" + NL);
+    }
+
+    // getCommonPropertyType()
+    elContext.setPropertyResolved(false);
+    Class<?> commonPropertyType = (compResolver.getCommonPropertyType(elContext, null));
+    buf.append("getCommonPropertyType() returns ");
+    buf.append(commonPropertyType.getName() + NL);
+
+    return pass;
+  }
+
+  public static boolean testELResolver(ELContext elContext, ELResolver resolver,
+      Object base, Object property, Object value, StringBuffer buf,
+      boolean readOnly) {
+
+    boolean pass = true;
+
+    // setValue()
+    elContext.setPropertyResolved(false);
+    try {
+      resolver.setValue(elContext, base, property, value);
+      if (readOnly) {
+        buf.append("setValue() failed on non-writable property");
+        pass = false;
+      } else {
+        buf.append(
+            "setValue() tested successfully on writable " + "property" + NL);
+      }
+
+    } catch (PropertyNotWritableException pnwe) {
+      if (readOnly) {
+        buf.append("setValue() tested successfully on non-writable "
+            + "property" + NL);
+        buf.append("PropertyNotWritableException caught as expected" + NL);
+      } else {
+        buf.append("setValue() failed on non-writable property" + NL);
+        buf.append("Unexpected PropertyNotWritableException caught" + NL);
+        pass = false;
+      }
+    }
+
+    // getValue()
+    elContext.setPropertyResolved(false);
+    Object valueRetrieved = resolver.getValue(elContext, base, property);
+    if (!elContext.isPropertyResolved()) {
+      buf.append("getValue() did not resolve" + NL);
+      pass = false;
+    }
+
+    if (!readOnly && !Objects.equals(valueRetrieved, value)) {
+      if (valueRetrieved == null) {
+        buf.append("null value returned from getValue() method call!" + NL);
+        pass = false;
+      } else {
+        buf.append("Invalid value from getValue():" + NL);
+        buf.append("Value expected: " + value.toString() + NL);
+        buf.append("Value retrieved: " + valueRetrieved.toString() + NL);
+        pass = false;
+      }
+    } else {
+      buf.append("getValue() tested successfully" + NL);
+      if (!readOnly) {
+        buf.append("Value expected: " + value.toString() + NL);
+        buf.append("Value retrieved: " + valueRetrieved.toString() + NL);
+      }
+    }
+
+    // getType()
+    elContext.setPropertyResolved(false);
+    Class<?> type = resolver.getType(elContext, base, property);
+    if (!elContext.isPropertyResolved()) {
+      buf.append("getType() did not resolve" + NL);
+      pass = false;
+    } else if (type != null) {
+      buf.append("getType() returns " + type.getName() + NL);
+      if (readOnly) {
+        buf.append("result not expected!" + NL);
+        pass = false;
+      } else {
+        buf.append("non-null as expected" + NL);
+      }
+    } else {
+      buf.append("getType() returns null " + NL);
+      if (!readOnly) {
+        buf.append("result not expected!" + NL);
+        pass = false;
+      } else {
+        buf.append("as expected" + NL);
+      }
+    }
+
+    // isReadOnly
+    elContext.setPropertyResolved(false);
+    boolean nonWritable = resolver.isReadOnly(elContext, base, property);
+    if (!elContext.isPropertyResolved()) {
+      buf.append("isReadOnly() did not resolve" + NL);
+      pass = false;
+    } else if (nonWritable != readOnly) {
+      buf.append("isReadOnly() returned unexpected value: " + nonWritable + NL);
+      pass = false;
+    } else {
+      buf.append("isReadOnly() returns " + readOnly + " as expected" + NL);
+    }
+
+    // getCommonPropertyType()
+    elContext.setPropertyResolved(false);
+    Class<?> commonPropertyType = (resolver.getCommonPropertyType(elContext, base));
+    buf.append("getCommonPropertyType() returns ");
+    buf.append(commonPropertyType.getName() + "" + NL);
+
+    return pass;
+  }
+
+  /**
+   * Test the ELResolver.invoke() mthod.
+   *
+   * @param elContext
+   *          - elContext
+   * @param resolver
+   *          - el Resolver to be tested.
+   * @param beanName
+   *          - The javabean to be used.
+   * @param methodName
+   *          - The method in the javabean to call.
+   * @param types
+   *          - The @class types of the aurgs for the method.
+   * @param values
+   *          - The args that you want to pass into the method.
+   * @param negTest
+   *          - Is this a negetive test or not(true, false).
+   * @param buf
+   *          - String buffer used to capture loggig info.
+   * @return {@code true} if the test passes otherwise {@code false}
+   */
+  public static boolean testELResolverInvoke(ELContext elContext,
+      ELResolver resolver, Object beanName, Object methodName, Class<?>[] types,
+      Object[] values, Boolean negTest, StringBuffer buf) {
+
+    boolean pass = true;
+
+    // invoke
+    elContext.setPropertyResolved(false);
+    try {
+      Boolean nameMatch = (Boolean) resolver.invoke(elContext, beanName,
+          methodName, types, values);
+
+      if (!nameMatch.booleanValue()) {
+        buf.append("invoke() did not Run properly." + NL);
+        pass = false;
+      }
+
+    } catch (MethodNotFoundException mnfe) {
+      if (negTest.booleanValue()) {
+        buf.append("Test Passed  invoke() threw MethodNotFoundException");
+      } else {
+        pass = false;
+        mnfe.printStackTrace();
+      }
+    } catch (Exception e) {
+      pass = false;
+      e.printStackTrace();
+    }
+
+    return pass;
+  }
+
+
+  // --- Start Negative Method Tests ---
+  public static boolean testELResolverNPE(ELResolver resolver, Object base,
+      Object property, Object value, StringBuffer buf) {
+
+    boolean pass = true;
+
+    // getType()
+    try {
+      resolver.getType(null, base, property);
+      pass = false;
+      buf.append("getType test failed with: " + NL
+          + "EXPECTED: NullPointerException to be thrown " + NL
+          + "RECEIVED: NO EXCEPTION THROWN AT ALL! " + NL);
+    } catch (Exception e) {
+      if (!(e instanceof NullPointerException)) {
+        buf.append("getType test failed with: " + NL + "EXPECTED: "
+            + "NullPointerException to be thrown " + NL + "RECEIVED: "
+            + e.toString() + NL);
+        pass = false;
+
+      } else {
+        buf.append("getType() test Passed: throws "
+            + "NullPointerException as expected " + NL);
+      }
+    }
+
+    // getValue
+    try {
+      resolver.getValue(null, base, property);
+      buf.append("Test Failed  getValue() did not throw any exception." + NL
+          + "Expected: NullPointerException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof NullPointerException)) {
+        buf.append("Test Failed  getValue() threw the wrong exception " + NL
+            + "Expected: NullPointerException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  getValue() threw NullPointerException " + NL);
+      }
+    }
+
+    // setValue()
+    try {
+      resolver.setValue(null, base, property, value);
+      buf.append("Test Failed  setValue() did not throw any exception." + NL
+          + "Expected: NullPointerException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof NullPointerException)) {
+        buf.append("Test Failed  setValue() threw the wrong exception " + NL
+            + "Expected: NullPointerException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  setValue() threw NullPointerException " + NL);
+      }
+    }
+
+    // isReadOnly()
+    try {
+      resolver.isReadOnly(null, base, property);
+      buf.append("Test Failed  isReadOnly() did not throw any exception." + NL
+          + "Expected: NullPointerException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof NullPointerException)) {
+        buf.append("Test Failed  isReadOnly() threw the wrong exception " + NL
+            + "Expected: NullPointerException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append(
+            "Test Passed  isReadOnly() NullPointerException " + "thrown " + NL);
+      }
+    }
+
+    return pass;
+  }
+
+  public static boolean testELResolverPNFE(ELContext elcontext,
+      ELResolver resolver, Object base, Object property, StringBuffer buf) {
+
+    boolean pass = true;
+
+    // getType()
+    try {
+      resolver.getType(elcontext, base, property);
+      buf.append("Test Failed  getType() did not throw any exception." + NL
+          + "Expected: PropertyNotFoundException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof PropertyNotFoundException)) {
+        buf.append("Test Failed  getType() threw the wrong exception " + NL
+            + "Expected: PropertyNotFoundException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  getType() threw "
+            + "PropertyNotFoundException " + NL);
+      }
+    }
+
+    // isReadOnly()
+    try {
+      resolver.isReadOnly(elcontext, base, property);
+      buf.append("Test Failed  isReadOnly() did not throw any exception." + NL
+          + "Expected: PropertyNotFoundException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof PropertyNotFoundException)) {
+        buf.append("Test Failed  isReadOnly() threw the wrong exception " + NL
+            + "Expected: PropertyNotFoundException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  isReadOnly() threw "
+            + "PropertyNotFoundException " + NL);
+      }
+    }
+
+    // setValue()
+    try {
+      resolver.setValue(elcontext, base, property, "arbitrary value");
+      buf.append("Test Failed  setValue() did not throw any exception." + NL
+          + "Expected: PropertyNotFoundException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof PropertyNotFoundException)) {
+        buf.append("Test Failed  setValue() threw the wrong exception " + NL
+            + "Expected: PropertyNotFoundException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  setValue() threw "
+            + "PropertyNotFoundException " + NL);
+      }
+    }
+
+    if (!(resolver instanceof BeanELResolver)) {
+      return pass;
+    }
+
+    // getValue()
+    try {
+      resolver.getValue(elcontext, base, property);
+      buf.append("Test Failed  getValue() did not throw any exception." + NL
+          + "Expected: PropertyNotFoundException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof PropertyNotFoundException)) {
+        buf.append("Test Failed  getValue() threw the wrong exception " + NL
+            + "Expected: PropertyNotFoundException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  getValue() threw "
+            + "PropertyNotFoundException " + NL);
+      }
+    }
+
+    return pass;
+  }
+
+  public static boolean testELResolverIAE(ELContext elcontext,
+      ELResolver resolver, Object base, Object property, Object value,
+      StringBuffer buf) {
+
+    boolean pass = true;
+
+    // getValue()
+    try {
+      resolver.getValue(elcontext, base, value);
+      buf.append("Test Failed  getValue() did not throw any exception." + NL
+          + "Expected: IllegalArgumentException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof IllegalArgumentException)) {
+        buf.append("Test Failed  getValue() threw the wrong exception " + NL
+            + "Expected: IllegalArgumentException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  getValue() threw "
+            + "IllegalArgumentException " + NL);
+      }
+    }
+
+    // setValue()
+    try {
+      resolver.setValue(elcontext, base, property, value);
+      buf.append("Test Failed  setValue() did not throw any exception." + NL
+          + "Expected: IllegalArgumentException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof IllegalArgumentException)) {
+        buf.append("Test Failed  setValue() threw the wrong exception "
+            + "Expected: IllegalArgumentException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  setValue() threw "
+            + "IllegalArgumentException " + NL);
+      }
+    }
+
+    return pass;
+  }
+
+  public static boolean testELResolverPNWE(ELContext elcontext,
+      ELResolver resolver, Object base, Object property, Object value,
+      StringBuffer buf) {
+
+    boolean pass = true;
+
+    // setValue()
+    try {
+      resolver.setValue(elcontext, base, property, value);
+      buf.append("Test Failed  setValue() did not throw any exception." + NL
+          + "Expected: PropertyNotWritableException " + NL);
+      pass = false;
+
+    } catch (Exception e) {
+      if (!(e instanceof PropertyNotWritableException)) {
+        buf.append("Test Failed  setValue() threw the wrong exception " + NL
+            + "Expected: PropertyNotWritableException " + NL + "Received: "
+            + e.toString());
+        pass = false;
+
+      } else {
+        buf.append("Test Passed  setValue() threw "
+            + "PropertyNotWritableException " + NL);
+      }
+    }
+
+    return pass;
+  }
+}

--- a/tck/src/main/java/ee/jakarta/tck/pages/spec/el/jsp/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/spec/el/jsp/URLClientIT.java
@@ -22,11 +22,10 @@
 package ee.jakarta.tck.pages.spec.el.jsp;
 
 
-import java.io.IOException;
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
+import ee.jakarta.tck.pages.common.el.Book;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 import ee.jakarta.tck.pages.common.tags.tck.SetTag;
-import com.sun.ts.tests.el.common.spec.Book;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
@@ -52,7 +51,7 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_el_jsp_web.war");

--- a/tck/src/main/java/ee/jakarta/tck/pages/spec/el/language/URLClientIT.java
+++ b/tck/src/main/java/ee/jakarta/tck/pages/spec/el/language/URLClientIT.java
@@ -22,11 +22,10 @@
 package ee.jakarta.tck.pages.spec.el.language;
 
 
-import java.io.IOException;
 import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
+import ee.jakarta.tck.pages.common.el.Book;
 import ee.jakarta.tck.pages.common.util.JspTestUtil;
 import ee.jakarta.tck.pages.common.tags.tck.SetTag;
-import com.sun.ts.tests.el.common.spec.Book;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
@@ -49,7 +48,7 @@ public class URLClientIT extends AbstractUrlClient {
   }
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static WebArchive createDeployment() {
 
     String packagePath = URLClientIT.class.getPackageName().replace(".", "/");
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "jsp_el_language_web.war");


### PR DESCRIPTION
Trying to build the Pages TCK with CI identified a dependency on the EL TCK. Since the TCKs are not published to Maven Central, remove the dependency and copy the few classes required.

Fix a few IDE warnings in affected clases at the same time